### PR TITLE
RFR - Add "authenticating an API - part 1" blog post

### DIFF
--- a/blog/authenticating_a_rails_api_part_1.md
+++ b/blog/authenticating_a_rails_api_part_1.md
@@ -1,0 +1,299 @@
+## So you want to sign up users and authenticate your Rails API - Step 1
+
+Hi folks. My name is Helen and I'm a Rails developer at Intrepid. That's right, we don't just do mobile. We also have a small but mighty web team that builds APIs, admin portals, and the like for our clients. And we're hiring!  Hit us up.
+
+It seems like every time we get a new crop of apprentices or start on a new project we ask ourselves: "Er, how do we do handle user sign up and authentication again?"
+
+And then we think: "Shouldn't we have written this down somewhere last time?"
+
+Yes, yes we should have. So now we are, for our and your benefit.
+
+Over the last few projects, we've come up with a fairly consistent approach to authenticating our APIs, which I'll outline in this and future blog posts. In this post, I'll review signing up users with email and password.  In future posts, I'll review:
+- allowing users to sign up via either email/password or an OAuth provider
+- authenticating API endpoints using [warden](https://github.com/hassox/warden).
+- regenerating API tokens when they expire
+
+### Overview
+
+Here's the whole sign-up and authentication flow:
+
+1. User signs up
+  * A first-time user submits their email and password to a `POST /users` endpoint.
+  * They get back a unique `authentication_token` to pass up in subsequent requests.
+2. User makes a request to an authenticated endpoint in your API
+  * They pass up their `authentication_token` in an `Authorization` header.
+  * If a user with that auth token exists and the auth token is not expired, the request proceeds.
+  * Otherwise, the server returns a `401 - Unauthorized` response.
+3. User regenerates a token
+  * If their token has expired, the user submits their email and password to a `POST /authentications` endpoint.
+  * A new token is generated for that user and is returned for use in subsequent requests.
+
+We'll tackle parts 1 and 3 today.  Follow along on [this repo](https://github.com/IntrepidPursuits/api-authentication-demo).
+
+### Tools we'll use
+
+- [ActiveModel::Serializers v. 0.8.3](https://github.com/rails-api/active_model_serializers/tree/0-8-stable)
+- [Monban](https://github.com/halogenandtoast/monban) and [Warden](https://github.com/hassox/warden)
+- RSpec and [json_spec](https://github.com/collectiveidea/json_spec) gem for testing
+- [Versionist](https://github.com/bploetz/versionist) for versioning the API
+
+### Let's get started
+
+#### Step 1: Write a test
+
+Because we're good little TDD-ers, we'll start with an integration test for our "happy path" case:
+
+```ruby
+# /spec/requests/v1/users_requests_spec.rb
+
+require 'rails_helper'
+
+describe 'Users endpoints' do
+  describe 'POST /users' do
+    context 'with valid email and password' do
+      it 'returns JSON for a user' do
+        user_attributes = {
+          user: {
+            email: user.email,
+            password: user.password_digest
+          }
+        }.to_json
+
+        post(users_url, user_attributes, accept_headers)
+
+        expect(response).to have_http_status :ok
+        expect_response_to_include_user_info
+      end
+    end
+  end
+
+  def user
+    @user ||= build(:user)
+  end
+
+  def expect_response_to_include_user_info
+    expect(json_value_at_path('user/email')).to eq user.email
+    expect(json_value_at_path('user/authentication_token')).to be
+    expect(json_value_at_path('user/authentication_token_expires_at')).to be
+  end
+end
+```
+
+We're making use of a couple of helper methods in our test that we can define in a `Helpers::Requests` mixin, namely:
+
+* `accept_headers` to generate a header with our vendor prefix and API version number
+* `json_value_at_path` for validating that JSON responses contain the correct values
+
+These rely on the `json_spec` gem's [helper methods](https://github.com/collectiveidea/json_spec#rspec), namely `parse_json`.
+
+```ruby
+# spec/support/helpers/requests.rb
+
+module Helpers
+  module Requests
+    def body
+      response.body
+    end
+
+    def json_value_at_path(path = '')
+      parse_json(body, path)
+    end
+
+    def api_version
+      1
+    end
+
+    def accept_header
+      "application/vnd.authentication-demo-app.com; version=#{api_version}"
+    end
+
+    def accept_headers
+      { 'Accept' => accept_header,
+        'Content-Type' => 'application/json' }
+    end
+  end
+end
+```
+
+Remember to register this helper, as well as the `json_spec` helpers, in your `rails_helper.rb`:
+
+```ruby
+RSpec.configure do |config|
+  # ...
+  config.include Helpers::Requests, type: :request
+  config.include JsonSpec::Helpers
+  # ...
+end
+```
+
+#### Step 2: Generate your user model
+
+Let's add a `User` model with `email`, `password_digest`, `authentication_token`, and `authentication_token_expires_at` required fields ([commit](https://github.com/IntrepidPursuits/api-authentication-demo/commit/20a49ca1b8f74b8e6834f99bd8ee66f3d0200a4es)).
+
+#### Step 3: Add your route and controller action
+
+We use the [versionist](https://github.com/bploetz/versionist) gem to enable versioning via an accept header.  Adding the route below:
+
+```ruby
+# config/routes.rb
+
+Rails.application.routes.draw do
+  api_version(module: 'V1',
+              header: {
+                name: 'Accept',
+                value: 'application/vnd.authentication-demo-app.com; version=1' },
+              defaults: { format: :json }) do
+    resources :users, only: :create
+  end
+end
+```
+
+will give us a route to the `v1/userss#create` controller action.  In that action, we'll use a `SignUpUser` service and an `AuthenticationSerializer` to serialize the user into JSON:
+
+```ruby
+# app/controllers/v1/users_controller.rb
+
+class V1::UsersController < V1::ApplicationController
+  def create
+    user = SignUpUser.perform(user_params)
+    render json: user, serializer: AuthenticationSerializer, root: :user
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:email, :password)
+  end
+end
+```
+
+([commit](https://github.com/IntrepidPursuits/api-authentication-demo/commit/e8975beba4523f9c7803c494c15e885f7d9d5bc7))
+
+#### Step 4: Add SignUpUser service
+
+The `SignUpUser` service is responsible for creating a new user given an email and password. We'll be using [Monban](https://github.com/halogenandtoast/monban) to sign up users.
+
+In addition to the `SignUpUser` service, we'll need to add:
+- A `reset_token!` method on the `User` model to set the authentication token, which we'll be able to use later on when we need to regenerate tokens as well.
+- An `AuthenticationToken` service, which will hold the logic for generating new (unique) tokens.
+
+Here's the [code](https://github.com/IntrepidPursuits/api-authentication-demo/commit/47b9d801648e85c58589e0648790833fd58f0dd1).
+
+#### Step 5: Add AuthenticationSerializer
+
+Our last step is to add an `AuthenticationSerializer` to serialize our newly-signed up user.
+
+First let's add a `BaseSerialier` that our other serializers will inherit from, which will include basic attributes and ensure that any associated records are [sideloaded rather than embedded](https://github.com/rails-api/active_model_serializers/tree/0-8-stable#embedding-associations).
+
+```ruby
+# app/serializers/base_serializer.rb
+
+class BaseSerializer < ActiveModel::Serializer
+  attributes :id, :created_at, :updated_at
+
+  embed :ids
+end
+```
+
+Now let's add our `AuthenticationSerializer` and return the user's token and expiry:
+
+```ruby
+# app/serializers/authentication_serializer.rb
+
+class AuthenticationSerializer < BaseSerializer
+  attributes :email, :authentication_token, :authentication_token_expires_at
+end
+```
+
+Our happy path request spec should now be passing!
+
+#### Step 6: Handle error cases
+
+Finally, we need to make sure that error cases (such as a user providing a pre-existing email) are handled properly.
+
+In this case, we want to return a "422 - Unprocessable entity" response along with helpful error messages.  Let's add our integration test:
+
+```ruby
+# /spec/requests/v1/users_requests_spec.rb
+
+context 'with errors' do
+  context 'such as a pre-existing email' do
+    it 'returns a 422 response and JSON for errors' do
+      existing_user = create(:user)
+
+      user_attributes = {
+        user: {
+          email: existing_user.email,
+          password: user.password_digest
+        }
+      }.to_json
+
+      post(users_url, user_attributes, accept_headers)
+
+      expect(response).to have_http_status :unprocessable_entity
+      expect(json_value_at_path('errors/0')).to eq 'Email has already been taken'
+    end
+  end
+end
+```
+
+And now let's make it pass:
+
+```ruby
+# app/controllers/v1/users_controller.rb
+
+def create
+  user = SignUpUser.perform(user_params)
+
+  if user.save
+    render json: user, serializer: AuthenticationSerializer, root: :user
+  else
+    render json: { errors: user.errors.full_messages },
+           status: :unprocessable_entity
+  end
+end
+```
+
+([commit](https://github.com/IntrepidPursuits/api-authentication-demo/commit/6559f931049bd163a2e6649ffeb358d7929c02ec))
+
+We could leave it like this and be done with our feature.  But since we nearly always this pattern in `create` actions of trying to save an object and rendering errors if it fails, let's instead raise an error and rescue that error in our base controller:
+
+```ruby
+# app/services/sign_up_user.rb
+
+def sign_up_user
+  user.tap do |user|
+    user.reset_token!
+    user.save! # raise error if validation fails
+  end
+end
+```
+
+```ruby
+# app/controllers/v1/users_controller.rb
+
+def create
+  user = SignUpUser.perform(user_params)
+  render json: user, serializer: AuthenticationSerializer, root: :user
+end
+```
+
+```ruby
+# app/controllers/application_controller.rb
+
+class ApplicationController < ActionController::Base
+  # ...
+
+  rescue_from ActiveRecord::RecordInvalid do |exception|
+    render json: { errors: exception.message }, status: :unprocessable_entity
+  end
+end
+```
+
+[commit](https://github.com/IntrepidPursuits/api-authentication-demo/commit/fa1920508491249459183827417aba3d72f5b56e)
+
+### That's it!
+
+Congratulations, you can now sign up users.
+
+Let us know if you have feedback or questions!  And stay tuned for our next post in the series.

--- a/blog/authenticating_a_rails_api_part_1.md
+++ b/blog/authenticating_a_rails_api_part_1.md
@@ -1,5 +1,7 @@
 ## So you want to sign up users and authenticate your Rails API - Step 1
 
+**Note:** This tutorial is designed for someone who has a beginning to intermediate knowledge of Ruby on Rails.
+
 Although Intrepid is primarily a mobile shop, we have a small but mighty web team that builds APIs, admin portals, and the like for our clients.  And for every API we’ve build, some sort of authentication system is required.  In this and subsequent posts, I’ll walk through the approach we’ve developed over a number of projects for user sign-up and authentication.
 
 In this post, I'll review signing up users with email and password.  In future posts, I'll review:

--- a/blog/authenticating_a_rails_api_part_2.md
+++ b/blog/authenticating_a_rails_api_part_2.md
@@ -1,0 +1,184 @@
+## So you want to sign up users and authenticate your Rails API - Part 2
+
+**Note:** This tutorial is designed for someone who has a beginning to intermediate knowledge of Ruby on Rails.
+
+In our last post, we reviewed signing up users via a `POST /users` endpoint in our API.  In this episode, we'll review how we authenticate users using an authentication token passed in the authorization header.
+
+### Overview
+
+We use [warden](https://github.com/hassox/warden) to authenticate our endpoints.  Warden lets you define custom strategies for restricting access to routes in your application. This is especially useful if you have different authentication rules for different endpoints.
+
+In this post, we'll create a `GET /widgets` endpoint that can only be accessed by our users.  We'll require users to pass up their authentication token in an authorization header like so:
+
+```
+GET /widgets
+Authorization: Token token=<my_token_here>
+```
+
+There are three components we'll need to implement:
+(1) A **constraint** to wrap our routes:
+
+    ```ruby
+    constraints AuthenticatedConstraint.new do
+      resources :widgets
+    end
+    ```
+
+(2) The Warden **strategy** that the constraint uses.
+(3) A **method** on our `User` model that will find a user given an authentication token.  Our strategy will use this method.
+
+### Tools we'll use
+
+- [Warden](https://github.com/hassox/warden)
+- RSpec and [json_spec](https://github.com/collectiveidea/json_spec) gem for testing
+
+### Let's get started
+
+#### Step 1: Write a test
+
+By the time we get to implementing an authentication system, we usually have at least one endpoint that requires authentication. So let's start with a `GET /widgets` endpoint that we want to restrict access to. ([commit](https://github.com/IntrepidPursuits/api-authentication-demo/commit/1d7756e182e455c6b3cface10e349c249d3b1682))
+
+Now let's add a test in our `widgets_requests_spec.rb` that ensures that a 401 status is returned if an unauthenticated user tries to access our endpoint:
+
+```ruby
+describe 'WidgetsController endpoints' do
+  describe 'GET /widgets' do
+    context 'with authenticated user' do
+      # ...
+    end
+
+    context 'without authenticated user' do
+      it 'returns a 401 - Unauthorized response' do
+        get(widgets_url, {}, accept_headers)
+
+        expect(response).to have_http_status :unauthorized
+      end
+    end
+  end
+end
+```
+
+This test should fail.
+
+#### Step 2: Add a constraint
+
+Rails' [constraints](http://guides.rubyonrails.org/routing.html#advanced-constraints) allow us to define rules for restricting access to particular routes in your app.  A constraint class must simply implement a method called `matches?` that returns true if access is allowed and false otherwise.
+
+Let's create a new constraint called `AuthenticatedConstraint` and use it to wrap our `GET /widgets` route.  Our constraint's `matches?` method will rely on the Warden strategy we'll implement next, which we'll call `TokenAuthenticationStrategy` to reflect the fact that it relies on an authentication token:
+
+```ruby
+# routes.rb
+
+constraints AuthenticatedConstraint.new do
+  resources :widgets, only: :index
+end
+```
+
+```ruby
+# app/constraints/authenticated_constraint.rb
+
+class AuthenticatedConstraint
+  def matches?(request)
+    warden = request.env['warden']
+    warden && warden.authenticate!(:token_authentication_strategy)
+  end
+end
+
+Warden::Strategies.add(:token_authentication_strategy,
+                       TokenAuthenticationStrategy)
+```
+
+What's going on here?  First, our constraint is grabbing the information that the Warden middleware inserts into the request's environment.  If that is present, it then uses Warden to call the `authenticate!` method that we'll define on our `TokenAuthenticationStrategy`.  This is a [convention of Warden strategies](https://github.com/hassox/warden/wiki/Strategies): they must implement an `authenticate!` method.
+
+Then we're telling Warden about our strategy by calling `Warden::Strategies.add` (which we could really do anywhere, but here seems as good a place as any).  This stores our `TokenAuthenticationStrategy` in a hash of strategies that Warden keeps track of.
+
+#### Step 3: Add our strategy
+
+Now let's add our Warden strategy:
+
+```ruby
+# app/strategies/token_authentication_strategy.rb
+
+class TokenAuthenticationStrategy < Warden::Strategies::Base
+  def valid?
+    env['HTTP_AUTHORIZATION'].present?
+  end
+
+  def authenticate!
+    if user
+      success!(user)
+    else
+      fail!(I18n.t('warden.messages.failure'))
+    end
+  end
+
+  def store?
+    false
+  end
+
+  def token
+    env['HTTP_AUTHORIZATION'].sub('Token token=', '')
+  end
+
+  def user
+    @user ||= User.
+              where(authentication_token: token).
+              where('authentication_token_expires_at > ?', Time.current).
+              first
+  end
+end
+```
+
+Let's walk through this.  Our class inherits from `Warden::Strategies::Base`, which gives us a few things:
+- A `success!` method that allows the request to proceed and sets the user in the request as `request.env['warden'].user`.
+- A `fail!` method that halts the request and calls Warden's failure app. The failure app tells Warden what to do if a request fails.  If we're using Monban to authenticate users using email and password, as we are, it [sets up a default failure app for us](https://github.com/halogenandtoast/monban/blob/29b2070a7592b08019f131f838c4ddea869e35e1/lib/monban/warden_setup.rb#L40) that will [return a 401 response](https://github.com/halogenandtoast/monban/blob/29b2070a7592b08019f131f838c4ddea869e35e1/spec/monban/test_helpers_spec.rb#L7).  If not, you'll have to set this yourself in `application.rb`:
+
+   ```ruby
+   config.middleware.use Warden::Manager do |manager|
+     manager.failure_app = lambda { |e| [ 401, {'Content-Type' => 'application/json'}, ['Authorization Failed'] ] }
+   end
+   ```
+
+Before calling `authenticate!`, Warden will first call our `valid?` method. If it returns false, Warden won't attempt to authenticate.
+
+Our `authenticate!` method pulls the token out of the request headers, looks for a user with that (unexpired) token, and calls Warden's `success!` or `fail!` methods depending on whether it finds such a user.
+
+There's one other thing here that's very important for authenticating API requests (as opposed to web requests).  Warden's [`store?`](https://github.com/hassox/warden/blob/74162f2bf896b377472b6621ed1f6b40046525f4/lib/warden/strategies/base.rb#L101) method determines whether a user should remain logged in across requests. If not overridden, this method returns `true`, which will allow user a user to pass a valid auth token once and then remain authenticated across subsequent requests.  This is :no_good:.
+
+Let's run our tests.  They should be passing!
+
+#### Step 4: Extract a `User#for_authentication` method
+
+We could leave as is and be done.  However, I usually extract the logic in `TokenAuthenticationStrategy#user` to a class method on the `User` model for easier testing. ([commit](https://github.com/IntrepidPursuits/api-authentication-demo/commit/712a125192aa22608900c1a5dba8beb4dbcea2de))
+
+```ruby
+# app/models/user.rb
+
+class User < ActiveRecord::Base
+  # ...
+
+  def self.for_authentication(token)
+    where(authentication_token: token).
+      where('authentication_token_expires_at > ?', Time.current).
+      first
+  end
+end
+```
+
+```ruby
+# app/strategies/token_authentication_strategy.rb
+
+class TokenAuthenticationStrategy < Warden::Strategies::Base
+  # ...
+
+  def user
+    @user ||= User.for_authentication(token)
+  end
+end
+```
+
+See the demo app repo for the new method's tests.
+
+### That's it!
+
+Tune in next time for our third part in this series, in which we'll add a `POST /authentications` endpoint to regenerate authentication tokens when a user's token expires.


### PR DESCRIPTION
This is part 1 in a (likely) 3-part tutorial on signing up users & authenticating an API and is a rough draft that needs review by the backend team (other reviewers also welcome!).

update 2/26: just added part 2
