### PR TITLE
Add framework for external 'stuff to read' pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ Development best practices for Intrepid
 ## Advice 
 * [Mobile API Guidance](mobile_api_guidance.md)
 
+## Resources
+* [Stuff to read for Android devs](android/stuff_to_read.md)
+* [Stuff to read for iOS devs](ios/stuff_to_read.md)
+* [Stuff to read for backend devs](backend/stuff_to_read.md)
+

--- a/android/stuff_to_read.md
+++ b/android/stuff_to_read.md
@@ -1,0 +1,6 @@
+# Android Resources
+Good stuff, cheap.
+
+## General
+* [Android Weekly](http://androidweekly.net/) - subscribe to it, great way to keep current.
+

--- a/backend/stuff_to_read.md
+++ b/backend/stuff_to_read.md
@@ -1,0 +1,3 @@
+# Backend Resources
+
+TODO

--- a/ios/stuff_to_read.md
+++ b/ios/stuff_to_read.md
@@ -1,0 +1,3 @@
+# iOS Resources
+
+TODO


### PR DESCRIPTION
Put in placeholder pages to fill with platform-specific useful links.
