### PR TITLE
Add a copy short hash helper

### DIFF
--- a/git_cookbook.md
+++ b/git_cookbook.md
@@ -58,3 +58,9 @@ One of the most common frustrations with submodules is failing to update them or
 ```
 git submodule update --init --recursive
 ```
+
+#### Copy the current short hash into the paste buffer
+
+```
+git log -n 1 --oneline | awk "{print \$1}" | tr -d \\n | pbcopy
+```


### PR DESCRIPTION
I also have it aliased with: `alias gsha='git log -n 1 --oneline | awk "{print \$1}" | tr -d \\n | pbcopy'`
