### PR TITLE
Add gradle template for setting app version

### DIFF
--- a/android/gradle.md
+++ b/android/gradle.md
@@ -1,0 +1,14 @@
+# Reusable Gradle Files
+Gradle scripts and tasks that might be useful for other projects can be 
+extracted out into their own files so that they can be reused. They can 
+be included by simply adding `apply from: 'example.gradle'` to the main 
+gradle file. Some of the gradle files that we use can be found under the 
+[gradle](gradle) folder.
+
+### [version.gradle](gradle/version.gradle)
+Often times it is useful for an app to indicate which git hash or
+Jenkins job it was build from so that QA can record the affected 
+builds when logging bugs and developers can go back to the appropriate 
+commit when trying to reproduce and fix them. [version.gradle](gradle/version.gradle) 
+include tasks to automatically append git short hash (if build locally) or the jenkins build number 
+(if build by Jenkins CI) to the original version name.

--- a/android/gradle/version.gradle
+++ b/android/gradle/version.gradle
@@ -1,0 +1,39 @@
+// This script will set the app version by either appending the git short hash (if build locally)
+// or the jenkins build number (if build by Jenkins CI) to the original version name.
+// To use this script, define `projectVersion` and then apply this file.
+// example:
+// ext.projectVersion = "1.12"
+// apply from: 'version.gradle'
+//
+// the main `build.gradle` file should delete the `versionName` line under the android
+// defaultConfig block
+
+android {
+    defaultConfig {
+        versionName = projectVersion + versionSuffix()
+    }
+}
+
+def gitShortHash() {
+    'git rev-parse --short HEAD'.execute().text.trim()
+}
+
+def gitHash() {
+    'git rev-parse HEAD'.execute().text.trim()
+}
+
+def buildNumber() {
+    return System.getenv("BUILD_NUMBER")
+}
+
+def versionSuffix() {
+    def buildNumber = buildNumber()
+    if (buildNumber) {
+        return "." + buildNumber
+    }
+
+    def shortHash = gitShortHash()
+    if (shortHash) {
+        return "." + shortHash
+    }
+}


### PR DESCRIPTION
The gradle script will set the app version by either appending the git short hash (if build locally) or the jenkins build number (if build by Jenkins CI) to the original version name.
