### PR TITLE
Adds a link to the iOS Jenkins guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Development best practices for Intrepid
 ## Platform-specific Resources
 * iOS
     * [iOS Resources](ios/README.md)
-    * [iOS Build Reporting On Jenkins Via Danger](ios/ios_danger.md)
+    * [iOS Jenkins Pipeline Setup](ios/ios_jenkins_pipeline_guide.md)
     * [iOS Code Coverage On Jenkins](ios/ios_code_coverage.md)
     * [Stuff to read for iOS devs](ios/stuff_to_read.md)
     * [Common CocoaPods](ios/common_cocoapods.md)


### PR DESCRIPTION
Saw that we were missing a link to @ButkiewiczP new Jenkins guide for pipelines