### PR TITLE
Update file names for syncing code style files.

### DIFF
--- a/android/code_style.md
+++ b/android/code_style.md
@@ -26,11 +26,11 @@ we'll go from there!
 ### Syncing the code style file
 Code style settings can also be checked into git and have the changes 
 be automatically synced across team members. This can be done by checking
-`.idea/codeStyleSettings.xml` into git and set the code style scheme in
-the settings dialog to `Project`. Normally, we put the whole `.idea` 
-folder under gitignore. However, we can make an exception for the code
-style file by putting the following lines in gitignore instead:
+`.idea/codeStyles/codeStyleConfig.xml` into git and set the code style
+scheme in the settings dialog to `Project`. Normally, we put the whole
+`.idea` folder under gitignore. However, we can make an exception for the
+code style file by putting the following lines in gitignore instead:
 ```
 .idea/*
-!.idea/codeStyleSettings.xml
+!.idea/codeStyles/codeStyleConfig.xml
 ```


### PR DESCRIPTION
Per [this link](https://confluence.jetbrains.com/display/IDEADEV/New+project+code+style+settings+format+in+2017.3) and trying this out on my new machine with the newest version of Android Studio, I was not able to locate the suggested `idea/codeStyleSettings.xml` to add to the .gitignore.